### PR TITLE
fix indentation error  hapi.yaml

### DIFF
--- a/packaging/ansible/ubuntu/hapi.yaml
+++ b/packaging/ansible/ubuntu/hapi.yaml
@@ -7,7 +7,7 @@
   tasks:
 
     - name: Add the OS specific variables
-        include_vars:
+      include_vars:
           file: index.yaml
 
     - name: hapi folder exists


### PR DESCRIPTION
Fix yaml indentation error on `include_vars`